### PR TITLE
site-navigation-language-web - adds custom configuration screen for the Language Template

### DIFF
--- a/modules/apps/site-navigation/site-navigation-language-web/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-language-web/build.gradle
@@ -5,7 +5,10 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:configuration-admin:configuration-admin-api")
+	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-taglib")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/configuration/LanguageTemplateConfigurationDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/configuration/LanguageTemplateConfigurationDisplayContext.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.language.web.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Drew Brokke
+ */
+public class LanguageTemplateConfigurationDisplayContext {
+
+	public void addTemplateValue(
+		String templateKey, String templateDisplayName) {
+
+		_templateValues.add(new String[] {templateKey, templateDisplayName});
+	}
+
+	public String getCurrentTemplateName() {
+		return _currentTemplateName;
+	}
+
+	public String getFieldLabel() {
+		return _fieldLabel;
+	}
+
+	public String getRedirect() {
+		return _redirect;
+	}
+
+	public List<String[]> getTemplateValues() {
+		return _templateValues;
+	}
+
+	public String getTitle() {
+		return _title;
+	}
+
+	public void setCurrentTemplateName(String currentTemplateName) {
+		_currentTemplateName = currentTemplateName;
+	}
+
+	public void setFieldLabel(String fieldLabel) {
+		_fieldLabel = fieldLabel;
+	}
+
+	public void setRedirect(String redirect) {
+		_redirect = redirect;
+	}
+
+	public void setTitle(String title) {
+		_title = title;
+	}
+
+	private String _currentTemplateName;
+	private String _fieldLabel;
+	private String _redirect;
+	private final List<String[]> _templateValues = new ArrayList<>();
+	private String _title;
+
+}

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/configuration/LanguageTemplateConfigurationScreen.java
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/configuration/LanguageTemplateConfigurationScreen.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.language.web.configuration;
+
+import com.liferay.configuration.admin.display.ConfigurationScreen;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
+import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.servlet.taglib.ui.LanguageEntry;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+
+import java.io.IOException;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(
+	configurationPid = "com.liferay.site.navigation.language.web.configuration.SiteNavigationLanguageWebTemplateConfiguration",
+	immediate = true, service = ConfigurationScreen.class
+)
+public class LanguageTemplateConfigurationScreen
+	implements ConfigurationScreen {
+
+	@Activate
+	public void activate(Map<String, Object> properties) {
+		_siteNavigationLanguageWebTemplateConfiguration =
+			ConfigurableUtil.createConfigurable(
+				SiteNavigationLanguageWebTemplateConfiguration.class,
+				properties);
+	}
+
+	@Override
+	public String getCategoryKey() {
+		return "localization";
+	}
+
+	@Override
+	public String getKey() {
+		return "site-navigation-language-web-template-configuration-name";
+	}
+
+	@Override
+	public String getName(Locale locale) {
+		return LanguageUtil.get(
+			ResourceBundleUtil.getBundle(
+				locale, LanguageTemplateConfigurationScreen.class),
+			getKey());
+	}
+
+	@Override
+	public String getScope() {
+		return "system";
+	}
+
+	@Override
+	public void render(HttpServletRequest request, HttpServletResponse response)
+		throws IOException {
+
+		Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		LanguageTemplateConfigurationDisplayContext
+			languageTemplateConfigurationDisplayContext =
+				new LanguageTemplateConfigurationDisplayContext();
+
+		languageTemplateConfigurationDisplayContext.setCurrentTemplateName(
+			_siteNavigationLanguageWebTemplateConfiguration.ddmTemplateKey());
+
+		long groupId = 0;
+
+		Group group = _groupLocalService.fetchCompanyGroup(
+			CompanyThreadLocal.getCompanyId());
+
+		if (group != null) {
+			groupId = group.getGroupId();
+		}
+
+		List<DDMTemplate> ddmTemplates = _ddmTemplateLocalService.getTemplates(
+			groupId, _portal.getClassNameId(LanguageEntry.class));
+
+		for (DDMTemplate ddmTemplate : ddmTemplates) {
+			languageTemplateConfigurationDisplayContext.addTemplateValue(
+				ddmTemplate.getTemplateKey(), ddmTemplate.getName(locale));
+		}
+
+		languageTemplateConfigurationDisplayContext.setRedirect(
+			_portal.getCurrentURL(request));
+
+		languageTemplateConfigurationDisplayContext.setTitle(getName(locale));
+
+		languageTemplateConfigurationDisplayContext.setFieldLabel(
+			"Language Selection Style");
+
+		request.setAttribute(
+			LanguageTemplateConfigurationDisplayContext.class.getName(),
+			languageTemplateConfigurationDisplayContext);
+
+		_jspRenderer.renderJSP(
+			_servletContext, request, response,
+			"/configuration/site_navigation_language_web_template.jsp");
+	}
+
+	@Reference
+	private DDMTemplateLocalService _ddmTemplateLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private JSPRenderer _jspRenderer;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.site.navigation.language.web)",
+		unbind = "-"
+	)
+	private ServletContext _servletContext;
+
+	private volatile SiteNavigationLanguageWebTemplateConfiguration
+		_siteNavigationLanguageWebTemplateConfiguration;
+
+}

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/internal/portlet/action/UpdateLanguageTemplateConfigurationMVCActionCommand.java
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/internal/portlet/action/UpdateLanguageTemplateConfigurationMVCActionCommand.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.language.web.internal.portlet.action;
+
+import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.site.navigation.language.web.configuration.SiteNavigationLanguageWebTemplateConfiguration;
+
+import java.util.Dictionary;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + ConfigurationAdminPortletKeys.SYSTEM_SETTINGS,
+		"mvc.command.name=/site_navigation_language/update_language_template_configuration"
+	},
+	service = MVCActionCommand.class
+)
+public class UpdateLanguageTemplateConfigurationMVCActionCommand
+	extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		String ddmTemplateKey = ParamUtil.getString(
+			actionRequest, "ddmTemplateKey");
+
+		Configuration configuration = _configurationAdmin.getConfiguration(
+			SiteNavigationLanguageWebTemplateConfiguration.class.getName(),
+			StringPool.QUESTION);
+
+		Dictionary<String, Object> properties = configuration.getProperties();
+
+		if (properties == null) {
+			properties = new HashMapDictionary<>();
+		}
+
+		properties.put("ddmTemplateKey", ddmTemplateKey);
+
+		configuration.update(properties);
+	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
+
+}

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/configuration/site_navigation_language_web_template.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/configuration/site_navigation_language_web_template.jsp
@@ -1,0 +1,53 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+LanguageTemplateConfigurationDisplayContext languageTemplateConfigurationDisplayContext = (LanguageTemplateConfigurationDisplayContext)request.getAttribute(LanguageTemplateConfigurationDisplayContext.class.getName());
+
+String currentTemplateName = languageTemplateConfigurationDisplayContext.getCurrentTemplateName();
+%>
+
+<portlet:actionURL name="/site_navigation_language/update_language_template_configuration" var="editURL" />
+
+<div class="sheet sheet-lb">
+	<div class="sheet-header">
+		<h2><%= languageTemplateConfigurationDisplayContext.getTitle() %></h2>
+	</div>
+
+	<aui:form action="<%= editURL %>" name="fm">
+		<aui:input name="redirect" type="hidden" value="<%= languageTemplateConfigurationDisplayContext.getRedirect() %>" />
+
+		<aui:select label="<%= HtmlUtil.escape(languageTemplateConfigurationDisplayContext.getFieldLabel()) %>" name="ddmTemplateKey" value="<%= currentTemplateName %>">
+
+			<%
+			for (String[] templateValue : languageTemplateConfigurationDisplayContext.getTemplateValues()) {
+			%>
+
+				<aui:option label="<%= templateValue[1] %>" selected="<%= currentTemplateName.equals(templateValue[0]) %>" value="<%= templateValue[0] %>" />
+
+			<%
+			}
+			%>
+
+		</aui:select>
+
+		<div class="sheet-footer">
+			<aui:button type="submit" />
+		</div>
+	</aui:form>
+</div>

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/init.jsp
@@ -25,6 +25,8 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.servlet.taglib.ui.LanguageEntry" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.site.navigation.language.web.configuration.LanguageTemplateConfigurationDisplayContext" %><%@
 page import="com.liferay.site.navigation.language.web.configuration.SiteNavigationLanguagePortletInstanceConfiguration" %><%@
 page import="com.liferay.site.navigation.language.web.internal.display.context.SiteNavigationLanguageDisplayContext" %>
 


### PR DESCRIPTION
Hey Russ, this is an example JSP for a custom configuration screen.  It is not multi-step, but it does svastly improve a real use-case we have.  Please let me know if you have any questions.<br><br>/cc @pei-jung @stsquared99 @alee8888 @jorgeferrer