### PR TITLE
There's still some issues with this rsync after ISSITES-6076

### DIFF
--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron/assets/liferay_jar_runner_set_up.sh
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron/assets/liferay_jar_runner_set_up.sh
@@ -32,7 +32,7 @@ function clone_repository {
 }
 
 function copy_images {
-	rsync --exclude=\"*\" --include=\"images/*\" --include=\"*/\" --prune-empty-dirs --recursive ~/liferay-learn/docs /public_html/images
+	rsync --include="images/*" --include="*/" --exclude="*" --prune-empty-dirs --recursive ~/liferay-learn/docs /public_html/images
 }
 
 function generate_zip_files {


### PR DESCRIPTION
After the argument sorting (probably done by BChan), the `copy_images` rsync wasn't working as expected, as discussed [here in slack](https://liferay.slack.com/archives/C03SJA564MS/p1683825590732319)

For the commit message I've hijacked the original "refactor after BChan" ticket:https://issues.liferay.com/browse/ISSITES-6076

@willnewbury @ryanschuhler @allen-ziegenfus let me know if there's something wrong with this (e.g., those escapes really are necessary, just not on my system)